### PR TITLE
Add SDK v1.3.0 cloud validation and approval docs

### DIFF
--- a/content/docs/api-reference/approvals.mdx
+++ b/content/docs/api-reference/approvals.mdx
@@ -1,0 +1,120 @@
+---
+title: GET /v1/approvals/:id
+description: Poll an approval record — used by the SDK to wait for human review.
+---
+
+When the validation endpoint returns `require_approval`, the SDK polls this endpoint until the approval is resolved by a human or expires.
+
+## Request
+
+```
+GET /v1/approvals/:id
+```
+
+### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-Veto-API-Key` | Yes | API key for authentication |
+
+### Path parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | `string` | The approval ID returned by the validate endpoint |
+
+## Response
+
+### Pending
+
+```json
+{
+  "id": "apr_abc123def456",
+  "status": "pending",
+  "toolName": "transfer_funds",
+  "arguments": { "amount": 5000, "to": "vendor-123" },
+  "createdAt": "2025-01-15T10:30:00Z",
+  "expiresAt": "2025-01-15T10:35:00Z"
+}
+```
+
+### Approved
+
+```json
+{
+  "id": "apr_abc123def456",
+  "status": "approved",
+  "toolName": "transfer_funds",
+  "resolvedBy": "user@company.com",
+  "resolvedAt": "2025-01-15T10:31:15Z"
+}
+```
+
+### Denied
+
+```json
+{
+  "id": "apr_abc123def456",
+  "status": "denied",
+  "toolName": "transfer_funds",
+  "resolvedBy": "user@company.com",
+  "resolvedAt": "2025-01-15T10:31:15Z"
+}
+```
+
+### Expired
+
+```json
+{
+  "id": "apr_abc123def456",
+  "status": "expired",
+  "toolName": "transfer_funds",
+  "expiresAt": "2025-01-15T10:35:00Z"
+}
+```
+
+### Response fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Approval record ID |
+| `status` | `"pending" \| "approved" \| "denied" \| "expired"` | Current status |
+| `toolName` | `string` | Name of the tool awaiting approval |
+| `arguments` | `object?` | Tool call arguments (included while pending) |
+| `resolvedBy` | `string?` | Who resolved the approval |
+| `resolvedAt` | `string?` | ISO 8601 timestamp of resolution |
+| `createdAt` | `string?` | ISO 8601 timestamp of creation |
+| `expiresAt` | `string?` | ISO 8601 timestamp of expiration |
+
+## SDK behavior
+
+The SDK handles polling automatically. You do not need to call this endpoint directly. The polling flow:
+
+1. Validate endpoint returns `{ decision: "require_approval", approval_id: "apr_..." }`
+2. SDK fires the `onApprovalRequired` / `on_approval_required` hook
+3. SDK polls `GET /v1/approvals/:id` every 2 seconds (configurable)
+4. When status changes from `pending`, SDK returns the decision to the agent
+5. If the poll exceeds the timeout (default 5 minutes), SDK throws `ApprovalTimeoutError`
+
+```
+Agent calls tool
+       │
+       ▼
+SDK validates with cloud ──── allow ──── Tool executes
+       │
+       ├── deny ──── ToolCallDeniedError
+       │
+       └── require_approval
+              │
+              ▼
+       Fire onApprovalRequired hook
+              │
+              ▼
+       Poll GET /v1/approvals/:id
+              │
+       ┌──────┼──────┐
+       │      │      │
+  approved  denied  expired/timeout
+       │      │      │
+  Tool runs  Error  Error
+```

--- a/content/docs/api-reference/meta.json
+++ b/content/docs/api-reference/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["validate"]
+  "pages": ["validate", "approvals"]
 }

--- a/content/docs/api-reference/validate.mdx
+++ b/content/docs/api-reference/validate.mdx
@@ -3,12 +3,12 @@ title: POST /v1/validate
 description: Core validation endpoint — validates a tool call against policies.
 ---
 
-The validation endpoint is the hot path. Every tool call intercepted by the SDK hits this endpoint when running in API mode.
+The validation endpoint is the hot path. Every tool call intercepted by the SDK hits this endpoint when running in cloud mode.
 
 ## Request
 
 ```
-POST /v1/validate
+POST /v1/tools/validate
 ```
 
 ### Headers
@@ -22,7 +22,7 @@ POST /v1/validate
 
 ```json
 {
-  "tool": "send_email",
+  "tool_name": "send_email",
   "arguments": {
     "to": "user@example.com",
     "subject": "Hello",
@@ -33,8 +33,9 @@ POST /v1/validate
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `tool` | `string` | Yes | Name of the tool being called |
+| `tool_name` | `string` | Yes | Name of the tool being called |
 | `arguments` | `object` | Yes | Arguments passed to the tool |
+| `context` | `object` | No | Additional metadata (call_id, session_id, etc.) |
 
 ## Response
 
@@ -53,18 +54,41 @@ POST /v1/validate
 {
   "decision": "deny",
   "reason": "Rule limit-transfers: amount 5000 exceeds limit of 1000",
-  "rule_id": "limit-transfers",
+  "failed_constraints": [
+    {
+      "parameter": "amount",
+      "constraint_type": "range",
+      "expected": 1000,
+      "actual": 5000,
+      "message": "amount 5000 exceeds maximum of 1000"
+    }
+  ],
   "latency_ms": 12
 }
 ```
+
+### Requires approval
+
+```json
+{
+  "decision": "require_approval",
+  "reason": "This tool call requires human review",
+  "approval_id": "apr_abc123def456",
+  "latency_ms": 30
+}
+```
+
+When the SDK receives `require_approval`, it automatically begins polling `GET /v1/approvals/:id` until the approval is resolved. See [Approvals](/docs/api-reference/approvals).
 
 ### Response fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `decision` | `"allow" \| "deny"` | Validation result |
-| `reason` | `string?` | Explanation when denied |
-| `rule_id` | `string?` | ID of the rule that triggered denial |
+| `decision` | `"allow" \| "deny" \| "require_approval"` | Validation result |
+| `reason` | `string?` | Explanation when denied or escalated |
+| `failed_constraints` | `array?` | Details of constraint violations |
+| `approval_id` | `string?` | Approval record ID (only with `require_approval`) |
+| `metadata` | `object?` | Additional metadata from the server |
 | `latency_ms` | `number` | Server-side processing time |
 
 ## Authentication
@@ -72,11 +96,11 @@ POST /v1/validate
 The API key is created in the Veto dashboard or via the `POST /v1/api-keys` endpoint. Each key is scoped to an organization and project.
 
 ```bash
-curl -X POST https://api.runveto.com/v1/validate \
+curl -X POST https://api.runveto.com/v1/tools/validate \
   -H "X-Veto-API-Key: veto_abc123..." \
   -H "Content-Type: application/json" \
   -d '{
-    "tool": "transfer_funds",
+    "tool_name": "transfer_funds",
     "arguments": { "amount": 500, "to": "vendor-123" }
   }'
 ```

--- a/content/docs/getting-started/quick-start.mdx
+++ b/content/docs/getting-started/quick-start.mdx
@@ -60,11 +60,10 @@ version: "1.0"
 mode: "strict"
 
 validation:
-  mode: "custom"     # "api", "kernel", or "custom"
+  mode: "cloud"     # "cloud", "api", "custom", or "kernel"
 
-custom:
-  provider: "openai"
-  model: "gpt-4o-mini"
+cloud:
+  apiKey: "veto_abc123..."
 
 rules:
   directory: "./rules"
@@ -73,7 +72,8 @@ rules:
 
 | Mode | How it works | When to use |
 |------|-------------|-------------|
-| `api` | Sends validation requests to the Veto server | Production with dashboard |
+| `cloud` | Validates via Veto Cloud API with approval workflows | Production with dashboard + human-in-the-loop |
+| `api` | Sends validation requests to a self-hosted API | Self-hosted deployments |
 | `custom` | Calls an LLM provider directly | Development, no server needed |
 | `kernel` | Uses a local Ollama model | Offline, air-gapped environments |
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -11,9 +11,9 @@ The agent is unaware of the guardrail. The tool interface is preserved.
 
 1. AI agent calls a tool (e.g. `send_email({to: "...", body: "..."})`)
 2. Veto intercepts the call via the SDK
-3. Arguments are validated against your rules (YAML constraints + LLM semantic checks)
-4. The call is allowed, blocked, or escalated based on the result
-5. If allowed, the tool executes normally. If blocked, the agent receives an error
+3. Arguments are validated against your policies (deterministic constraints + LLM semantic checks)
+4. The call is allowed, blocked, or escalated for human approval
+5. If allowed, the tool executes normally. If blocked, the agent receives an error. If escalated, a human reviewer approves or denies.
 
 ```
 ┌──────────┐     ┌───────┐     ┌──────────┐
@@ -22,6 +22,12 @@ The agent is unaware of the guardrail. The tool interface is preserved.
 │  calls   │     │ rules │     │ execute  │
 │  tools   │     │ + LLM │     │ actions  │
 └──────────┘     └───────┘     └──────────┘
+                    │
+                    ▼
+              ┌──────────┐
+              │  Human   │
+              │ Approval │
+              └──────────┘
 ```
 
 ## Features
@@ -29,8 +35,10 @@ The agent is unaware of the guardrail. The tool interface is preserved.
 - **Provider agnostic** — works with OpenAI, Anthropic, Google, LangChain, Vercel AI SDK
 - **YAML rules** — define constraints with simple, declarative YAML
 - **LLM validation** — semantic checks for cases static rules can't cover
-- **Multiple validation modes** — API (remote server), custom (direct LLM), or kernel (local Ollama)
-- **TypeScript + Python SDKs** — first-class support for both languages
+- **Human-in-the-loop** — escalate sensitive tool calls for human approval before execution
+- **Approval preferences** — cache approve/deny decisions per tool to skip repeated reviews
+- **Multiple validation modes** — cloud (managed), API (self-hosted), custom (direct LLM), or kernel (local Ollama)
+- **TypeScript + Python SDKs** — first-class support for both languages with identical APIs
 - **Dashboard** — real-time monitoring at [runveto.com](https://runveto.com)
 
 ## Quick example
@@ -38,11 +46,16 @@ The agent is unaware of the guardrail. The tool interface is preserved.
 ```typescript
 import { Veto } from 'veto-sdk';
 
-const veto = await Veto.init();
+const veto = await Veto.init({
+  onApprovalRequired: (context, approvalId) => {
+    console.log(`"${context.toolName}" needs approval: ${approvalId}`);
+  },
+});
+
 const wrappedTools = veto.wrap(myTools);
 
 // Pass wrapped tools to your agent — it works exactly the same,
-// but every call is now validated against your rules
+// but every call is now validated against your policies
 const agent = createAgent({ tools: wrappedTools });
 ```
 
@@ -51,3 +64,4 @@ const agent = createAgent({ tools: wrappedTools });
 - [Installation](/docs/getting-started/installation) — install the SDK for TypeScript or Python
 - [Quick Start](/docs/getting-started/quick-start) — get Veto running in 5 minutes
 - [Rule Format](/docs/rules/yaml-format) — learn the YAML rule syntax
+- [Validation Modes](/docs/rules/validation-modes) — cloud, API, custom, and kernel modes

--- a/content/docs/rules/validation-modes.mdx
+++ b/content/docs/rules/validation-modes.mdx
@@ -1,32 +1,64 @@
 ---
 title: Validation Modes
-description: How Veto validates tool calls — API, custom, and kernel modes.
+description: How Veto validates tool calls — cloud, API, custom, and kernel modes.
 ---
 
-Veto supports three validation modes, configured in `veto.config.yaml`:
+Veto supports four validation modes, configured in `veto.config.yaml`:
 
 ```yaml
 validation:
-  mode: "custom"  # "api", "custom", or "kernel"
+  mode: "cloud"  # "cloud", "api", "custom", or "kernel"
 ```
+
+## Cloud mode
+
+Routes validation through the Veto Cloud API with full policy management, decision logging, and human-in-the-loop approval workflows.
+
+```yaml
+validation:
+  mode: "cloud"
+
+cloud:
+  apiKey: "veto_abc123..."
+  baseUrl: "https://api.runveto.com"
+  timeout: 30000
+  retries: 2
+
+approval:
+  pollInterval: 2000   # ms between polls
+  timeout: 300000      # max ms to wait (5 min)
+```
+
+The cloud can return three decisions:
+
+| Decision | What happens |
+|----------|-------------|
+| `allow` | Tool call proceeds |
+| `deny` | Tool call is blocked |
+| `require_approval` | SDK pauses and polls until a human approves or denies |
+
+When `require_approval` is returned, the SDK fires the `onApprovalRequired` hook (TypeScript) or `on_approval_required` callback (Python), then polls `GET /v1/approvals/:id` until resolved. This enables integrations like the Veto dashboard to present approve/deny UI to a human reviewer.
+
+Best for production deployments. Provides:
+- Centralized policy management via the dashboard at [runveto.com](https://runveto.com)
+- Deterministic and LLM-assisted validation
+- Real-time decision logging
+- Human-in-the-loop approval workflows
+- Team-wide visibility and audit trails
 
 ## API mode
 
-Sends validation requests to the Veto server at `POST /v1/validate`.
+Sends validation requests to a self-hosted or external validation API at `POST /tool/call/check`.
 
 ```yaml
 validation:
   mode: "api"
   api:
-    url: "https://api.runveto.com"
-    key: "veto_abc123..."
+    url: "http://localhost:8080"
+    endpoint: "/tool/call/check"
 ```
 
-Best for production deployments with the Veto dashboard. Provides:
-- Centralized policy management
-- Real-time decision logging
-- Approval workflows for escalated calls
-- Team-wide visibility via the dashboard at [runveto.com](https://runveto.com)
+Best for self-hosted deployments or custom validation backends.
 
 ## Custom mode
 

--- a/content/docs/sdk/python.mdx
+++ b/content/docs/sdk/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: Full API reference for the Veto Python SDK.
+description: Full API reference for the Veto Python SDK (v0.3.0).
 ---
 
 ## Installation
@@ -20,7 +20,7 @@ pip install veto[all]         # All providers
 
 ## `Veto.init(options?)`
 
-Initialize Veto. Loads configuration from `./veto` by default.
+Initialize Veto. Uses the `VETO_API_KEY` environment variable by default.
 
 ```python
 from veto import Veto
@@ -28,9 +28,41 @@ from veto import Veto
 veto = await Veto.init()
 ```
 
+### Options
+
+Pass a `VetoOptions` dataclass to customize initialization:
+
+```python
+from veto import Veto, VetoOptions
+
+veto = await Veto.init(VetoOptions(
+    api_key="veto_abc123...",
+    base_url="https://api.runveto.com",
+    mode="strict",
+    on_approval_required=my_approval_handler,
+    approval_poll_interval=2.0,   # seconds
+    approval_timeout=300.0,       # seconds
+))
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `api_key` | `str` | `VETO_API_KEY` env | API key for Veto Cloud |
+| `base_url` | `str` | `"https://api.veto.dev"` | Cloud API base URL |
+| `mode` | `"strict" \| "log"` | `"strict"` | Operating mode |
+| `log_level` | `str` | `"info"` | Log level |
+| `session_id` | `str` | — | Session ID for tracking |
+| `agent_id` | `str` | — | Agent ID for tracking |
+| `validators` | `list` | — | Additional validators |
+| `timeout` | `int` | `30000` | API timeout in ms |
+| `retries` | `int` | `2` | Retry count |
+| `on_approval_required` | `callable` | — | Hook fired when a tool call needs human approval |
+| `approval_poll_interval` | `float` | `2.0` | Seconds between approval polls |
+| `approval_timeout` | `float` | `300.0` | Max seconds to wait for approval |
+
 ## `veto.wrap(tools)`
 
-Wraps an array of tools with validation.
+Wraps an array of tools with validation. Auto-registers tool signatures with Veto Cloud for policy generation.
 
 ```python
 wrapped_tools = veto.wrap(my_tools)
@@ -59,6 +91,131 @@ Resets the history statistics.
 
 ```python
 veto.clear_history()
+```
+
+## Error handling
+
+When a tool call is blocked, Veto raises a `ToolCallDeniedError`:
+
+```python
+from veto import ToolCallDeniedError
+
+try:
+    await wrapped_tool.ainvoke(args)
+except ToolCallDeniedError as e:
+    print(e.tool_name)   # "transfer_funds"
+    print(e.call_id)     # "call_abc123"
+```
+
+When an approval poll times out, Veto raises an `ApprovalTimeoutError`:
+
+```python
+from veto.cloud.client import ApprovalTimeoutError
+
+try:
+    await wrapped_tool.ainvoke(args)
+except ApprovalTimeoutError as e:
+    print(e.approval_id)  # "apr_abc123"
+    print(e.timeout)      # 300.0
+```
+
+## Cloud validation and approvals
+
+The Python SDK validates tool calls through the Veto Cloud API. The server can return three decisions: `allow`, `deny`, or `require_approval`.
+
+When a tool call requires approval, the SDK:
+
+1. Fires the `on_approval_required` callback (so your app can show approval UI)
+2. Polls `GET /v1/approvals/:id` until a human approves or denies
+3. Returns the final decision to the agent
+
+```python
+async def handle_approval(context, approval_id):
+    print(f"Tool '{context.tool_name}' needs approval: {approval_id}")
+
+veto = await Veto.init(VetoOptions(
+    on_approval_required=handle_approval,
+))
+```
+
+The callback receives the full `ValidationContext` and the `approval_id` string. It can be sync or async.
+
+### Approval preference cache
+
+Cache per-tool preferences to auto-resolve approvals without server polling:
+
+```python
+# Auto-approve all future calls to "read_file"
+veto.set_approval_preference("read_file", "approve_all")
+
+# Auto-deny all future calls to "delete_database"
+veto.set_approval_preference("delete_database", "deny_all")
+
+# Check current preference
+veto.get_approval_preference("read_file")  # "approve_all"
+
+# Clear preference for one tool
+veto.clear_approval_preferences("read_file")
+
+# Clear all preferences
+veto.clear_approval_preferences()
+```
+
+## `VetoCloudClient`
+
+Standalone client for direct cloud API interaction:
+
+```python
+from veto.cloud.client import VetoCloudClient, VetoCloudConfig
+
+client = VetoCloudClient(
+    config=VetoCloudConfig(
+        api_key="veto_abc123...",
+        base_url="https://api.runveto.com",
+        timeout=30000,
+        retries=2,
+    ),
+)
+```
+
+### `await client.validate(tool_name, arguments, context?)`
+
+```python
+result = await client.validate("send_email", {
+    "to": "user@example.com",
+    "subject": "Hello",
+})
+# ValidationResponse(decision="allow"|"deny"|"require_approval", reason=..., approval_id=...)
+```
+
+### `await client.poll_approval(approval_id, options?)`
+
+```python
+from veto.cloud.types import ApprovalPollOptions
+
+approval = await client.poll_approval("apr_abc123", ApprovalPollOptions(
+    poll_interval=2.0,  # seconds
+    timeout=300.0,      # seconds
+))
+# ApprovalData(id=..., status="approved"|"denied"|"expired", resolved_by=...)
+```
+
+### `await client.register_tools(tools)`
+
+```python
+from veto.cloud.types import ToolRegistration, ToolParameter
+
+await client.register_tools([
+    ToolRegistration(
+        name="send_email",
+        description="Send an email",
+        parameters=[
+            ToolParameter(name="to", type="string", required=True),
+            ToolParameter(name="subject", type="string", required=True),
+            ToolParameter(name="body", type="string", required=True),
+        ],
+    ),
+])
 ```
 
 ## CLI commands

--- a/content/docs/sdk/typescript.mdx
+++ b/content/docs/sdk/typescript.mdx
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: Full API reference for the Veto TypeScript SDK.
+description: Full API reference for the Veto TypeScript SDK (v1.3.0).
 ---
 
 ## Installation
@@ -18,6 +18,19 @@ import { Veto } from 'veto-sdk';
 
 const veto = await Veto.init();
 ```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `configDir` | `string` | `"./veto"` | Path to config directory |
+| `mode` | `"strict" \| "log"` | `"strict"` | Operating mode |
+| `logLevel` | `string` | `"info"` | Log level |
+| `sessionId` | `string` | — | Session ID for tracking |
+| `agentId` | `string` | — | Agent ID for tracking |
+| `validators` | `Validator[]` | — | Additional validators |
+| `cloudClient` | `VetoCloudClient` | — | Injected cloud client |
+| `onApprovalRequired` | `(context, approvalId) => void` | — | Hook fired when a tool call needs human approval |
 
 ## `veto.wrap<T>(tools: T[]): T[]`
 
@@ -72,6 +85,137 @@ try {
 }
 ```
 
+When an approval poll times out, Veto throws an `ApprovalTimeoutError`:
+
+```typescript
+import { ApprovalTimeoutError } from 'veto-sdk/cloud';
+
+try {
+  await wrappedTool.invoke(args);
+} catch (error) {
+  if (error instanceof ApprovalTimeoutError) {
+    console.log(error.approvalId);  // "apr_abc123"
+    console.log(error.timeoutMs);   // 300000
+  }
+}
+```
+
+## Cloud validation and approvals
+
+When using `cloud` validation mode, the SDK routes tool calls through the Veto Cloud API. The server can return three decisions: `allow`, `deny`, or `require_approval`.
+
+When a tool call requires approval, the SDK:
+
+1. Fires the `onApprovalRequired` hook (so your app can show approval UI)
+2. Polls `GET /v1/approvals/:id` until a human approves or denies
+3. Returns the final decision to the agent
+
+```typescript
+const veto = await Veto.init({
+  onApprovalRequired: (context, approvalId) => {
+    // Show approval UI to the user
+    console.log(`Tool "${context.toolName}" needs approval: ${approvalId}`);
+  },
+});
+```
+
+### Configuration
+
+Configure approval polling in `veto.config.yaml`:
+
+```yaml
+validation:
+  mode: "cloud"
+
+cloud:
+  apiKey: "veto_abc123..."
+  baseUrl: "https://api.runveto.com"
+
+approval:
+  pollInterval: 2000   # ms between polls (default: 2000)
+  timeout: 300000      # max ms to wait (default: 300000 = 5 min)
+```
+
+### Approval preference cache
+
+Cache per-tool preferences to auto-resolve approvals without server polling:
+
+```typescript
+// Auto-approve all future calls to "read_file"
+veto.setApprovalPreference('read_file', 'approve_all');
+
+// Auto-deny all future calls to "delete_database"
+veto.setApprovalPreference('delete_database', 'deny_all');
+
+// Check current preference
+veto.getApprovalPreference('read_file'); // "approve_all"
+
+// Clear preference for one tool
+veto.clearApprovalPreferences('read_file');
+
+// Clear all preferences
+veto.clearApprovalPreferences();
+```
+
+## `VetoCloudClient`
+
+Standalone client for direct cloud API interaction. Used internally by `Veto`, but also available for advanced use cases.
+
+```typescript
+import { VetoCloudClient } from 'veto-sdk/cloud';
+
+const client = new VetoCloudClient({
+  config: {
+    apiKey: 'veto_abc123...',
+    baseUrl: 'https://api.runveto.com',
+    timeout: 30000,
+    retries: 2,
+    retryDelay: 1000,
+  },
+  logger,
+});
+```
+
+### `client.validate(toolName, args, context?)`
+
+Validate a tool call against cloud policies.
+
+```typescript
+const result = await client.validate('send_email', {
+  to: 'user@example.com',
+  subject: 'Hello',
+});
+// { decision: "allow" | "deny" | "require_approval", reason?, approval_id? }
+```
+
+### `client.pollApproval(approvalId, options?)`
+
+Poll an approval record until resolved or timed out.
+
+```typescript
+const approval = await client.pollApproval('apr_abc123', {
+  pollInterval: 2000,  // ms
+  timeout: 300000,     // ms
+});
+// { id, toolName, status: "approved" | "denied" | "expired", resolvedBy? }
+```
+
+### `client.registerTools(tools)`
+
+Register tool signatures with the cloud for policy generation.
+
+```typescript
+await client.registerTools([{
+  name: 'send_email',
+  description: 'Send an email',
+  parameters: [
+    { name: 'to', type: 'string', required: true },
+    { name: 'subject', type: 'string', required: true },
+    { name: 'body', type: 'string', required: true },
+  ],
+}]);
+```
+
 ## Provider adapters
 
 The SDK includes adapters that convert tool definitions between formats:
@@ -97,3 +241,5 @@ The SDK publishes multiple entry points:
 | `veto-sdk/rules` | Rule parsing and matching utilities |
 | `veto-sdk/kernel` | Local model evaluation via Ollama |
 | `veto-sdk/custom` | Direct LLM provider integration |
+| `veto-sdk/compiler` | Rule compiler utilities |
+| `veto-sdk/benchmark` | Performance benchmarking |


### PR DESCRIPTION
## Summary

- Document the new `require_approval` flow with human-in-the-loop approval for both TypeScript SDK (v1.3.0) and Python SDK (v0.3.0)
- Add `cloud` as a fourth validation mode alongside API, custom, and kernel
- Create new `GET /v1/approvals/:id` API reference page with full request/response docs and flow diagram
- Update landing page and quick start to reflect approval workflow capabilities

## Changes

**New page:**
- `content/docs/api-reference/approvals.mdx` — Approval polling endpoint docs with status lifecycle and ASCII flow diagram

**Updated pages:**
- `content/docs/sdk/typescript.mdx` — `VetoOptions` table, `onApprovalRequired` hook, `ApprovalTimeoutError`, cloud validation section, `VetoCloudClient` API, approval preference cache methods, updated exports table
- `content/docs/sdk/python.mdx` — `VetoOptions` dataclass, `on_approval_required` callback, `ApprovalTimeoutError`, cloud validation section, `VetoCloudClient` API, approval preference cache methods
- `content/docs/rules/validation-modes.mdx` — New "Cloud mode" as primary mode with three-decision table (allow/deny/require_approval), updated from 3 to 4 modes
- `content/docs/api-reference/validate.mdx` — Added `require_approval` response type, `failed_constraints` array, `approval_id` field, updated endpoint to `POST /v1/tools/validate`, link to approvals page
- `content/docs/api-reference/meta.json` — Added approvals page to navigation
- `content/docs/index.mdx` — Added human-in-the-loop and approval preferences to features list, updated diagram to show approval path, updated quick example with `onApprovalRequired` hook
- `content/docs/getting-started/quick-start.mdx` — Added cloud mode to validation modes table, updated default config example

## Testing

- `pnpm build` passes with all 14 pages (including new approvals page) generating successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud validation mode supporting human-in-the-loop approval workflows
  * Approval status checking API endpoint

* **Documentation**
  * Added comprehensive approvals API reference guide
  * Updated validation endpoint path and request parameters
  * Expanded SDK documentation for Python and TypeScript with approval handling examples
  * Introduced new validation modes and cloud configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->