### PR TITLE
Update docs for SDK v1.4.0

### DIFF
--- a/content/docs/api-reference/decisions.mdx
+++ b/content/docs/api-reference/decisions.mdx
@@ -1,0 +1,115 @@
+---
+title: POST /v1/decisions
+description: Log a client-side validation decision — keeps the dashboard audit trail complete.
+---
+
+When the SDK validates a tool call locally (client-side deterministic), it logs the decision back to the server so the dashboard and audit trail stay accurate.
+
+This endpoint is called automatically by the SDK. You do not need to call it directly.
+
+## Request
+
+```
+POST /v1/decisions
+```
+
+### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-Veto-API-Key` | Yes | API key scoped to a project |
+| `Content-Type` | Yes | `application/json` |
+
+### Body
+
+```json
+{
+  "tool_name": "transfer_funds",
+  "arguments": { "amount": 500, "to": "vendor-123" },
+  "decision": "allow",
+  "reason": "All constraints passed",
+  "mode": "deterministic",
+  "latency_ms": 2,
+  "source": "client",
+  "context": {
+    "session_id": "sess_abc123",
+    "agent_id": "agent_1"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `tool_name` | `string` | Yes | Name of the tool that was validated |
+| `arguments` | `object` | Yes | Arguments that were validated |
+| `decision` | `"allow" \| "deny"` | Yes | Validation result |
+| `reason` | `string` | No | Explanation of the decision |
+| `mode` | `"deterministic"` | Yes | Validation mode used |
+| `latency_ms` | `number` | Yes | Client-side validation time in milliseconds |
+| `source` | `"client"` | Yes | Must be `"client"` |
+| `context` | `object` | No | Additional metadata (session_id, agent_id, etc.) |
+
+## Response
+
+### Success
+
+```json
+{
+  "success": true,
+  "id": "d7f2a1b3-4c5e-6f78-9a0b-1c2d3e4f5a6b"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the decision was logged |
+| `id` | `string` | UUID of the created decision record |
+
+### Error: missing project
+
+```json
+{
+  "error": {
+    "code": "missing_project",
+    "message": "API key must be scoped to a project"
+  }
+}
+```
+
+Returned when the API key is org-scoped but not project-scoped. Decision logging requires a project context.
+
+## Rate limiting
+
+120 requests per 60 seconds per API key.
+
+## SDK behavior
+
+The SDK calls this endpoint automatically after every client-side deterministic validation. The call is fire-and-forget — errors are silently swallowed so they never block tool execution.
+
+Both TypeScript and Python SDKs use the same behavior:
+
+```typescript
+// TypeScript — called internally by tryLocalDeterministic()
+client.logDecision({
+  tool_name: 'send_email',
+  arguments: { to: 'user@example.com' },
+  decision: 'allow',
+  mode: 'deterministic',
+  latency_ms: 2,
+  source: 'client',
+});
+```
+
+```python
+# Python — called internally by try_local_deterministic()
+client.log_decision({
+    "tool_name": "send_email",
+    "arguments": {"to": "user@example.com"},
+    "decision": "allow",
+    "mode": "deterministic",
+    "latency_ms": 2,
+    "source": "client",
+})
+```
+
+Decisions logged via this endpoint appear in the dashboard alongside server-side decisions. They are marked with `source: "client"` in the context field.

--- a/content/docs/api-reference/meta.json
+++ b/content/docs/api-reference/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["validate", "approvals"]
+  "pages": ["validate", "decisions", "approvals"]
 }

--- a/content/docs/api-reference/validate.mdx
+++ b/content/docs/api-reference/validate.mdx
@@ -3,7 +3,9 @@ title: POST /v1/validate
 description: Core validation endpoint — validates a tool call against policies.
 ---
 
-The validation endpoint is the hot path. Every tool call intercepted by the SDK hits this endpoint when running in cloud mode.
+The validation endpoint is the primary API for tool call validation. In cloud mode, the SDK calls this endpoint for every tool call that can't be resolved locally.
+
+As of SDK v1.4.0, deterministic policies are cached client-side. When the SDK has a fresh cached policy, validation runs locally (~1-5ms) and this endpoint is not called. Decisions from local validation are logged asynchronously via [POST /v1/decisions](/docs/api-reference/decisions).
 
 ## Request
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -34,6 +34,7 @@ The agent is unaware of the guardrail. The tool interface is preserved.
 
 - **Provider agnostic** — works with OpenAI, Anthropic, Google, LangChain, Vercel AI SDK
 - **YAML rules** — define constraints with simple, declarative YAML
+- **Client-side validation** — deterministic constraints evaluated locally with zero network latency. Policies synced from the cloud and cached with stale-while-revalidate.
 - **LLM validation** — semantic checks for cases static rules can't cover
 - **Human-in-the-loop** — escalate sensitive tool calls for human approval before execution
 - **Approval preferences** — cache approve/deny decisions per tool to skip repeated reviews

--- a/content/docs/rules/validation-modes.mdx
+++ b/content/docs/rules/validation-modes.mdx
@@ -39,8 +39,21 @@ The cloud can return three decisions:
 
 When `require_approval` is returned, the SDK fires the `onApprovalRequired` hook (TypeScript) or `on_approval_required` callback (Python), then polls `GET /v1/approvals/:id` until resolved. This enables integrations like the Veto dashboard to present approve/deny UI to a human reviewer.
 
+### Client-side fast path
+
+In cloud mode, the SDK caches policies locally and evaluates deterministic constraints without a network round-trip. This happens automatically when:
+
+1. The tool's policy is cached (fetched on first call, refreshed in background)
+2. The policy mode is `deterministic` (not `llm`)
+3. The policy has no session constraints or rate limits
+
+When all three conditions are met, validation runs in the SDK (~1-5ms). The decision is logged to the server asynchronously via `POST /v1/decisions` so the dashboard stays accurate.
+
+If any condition is not met, the SDK falls through to `POST /v1/validate` as before.
+
 Best for production deployments. Provides:
 - Centralized policy management via the dashboard at [runveto.com](https://runveto.com)
+- Client-side deterministic validation with zero-latency cache hits
 - Deterministic and LLM-assisted validation
 - Real-time decision logging
 - Human-in-the-loop approval workflows

--- a/content/docs/sdk/python.mdx
+++ b/content/docs/sdk/python.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python SDK
-description: Full API reference for the Veto Python SDK (v0.3.0).
+description: Full API reference for the Veto Python SDK (v0.4.0).
 ---
 
 ## Installation
@@ -161,6 +161,40 @@ veto.clear_approval_preferences("read_file")
 veto.clear_approval_preferences()
 ```
 
+## Client-side deterministic validation
+
+The Python SDK evaluates deterministic constraints locally when a cached policy is available, identical to the TypeScript SDK. No network round-trip needed for simple checks like number ranges, string enums, or regex patterns.
+
+This is automatic in cloud mode. When the SDK has a cached policy for a tool and that policy uses `deterministic` mode without session constraints or rate limits, validation runs locally. Decisions are logged back to the server asynchronously.
+
+### Supported constraint types
+
+| Constraint | Applies to | Description |
+|-----------|-----------|-------------|
+| `required` | all | Argument must be present |
+| `not_null` | all | Argument cannot be None |
+| `minimum` | numbers | Lower bound (inclusive) |
+| `maximum` | numbers | Upper bound (inclusive) |
+| `greater_than` | numbers | Lower bound (exclusive) |
+| `less_than` | numbers | Lower bound (exclusive) |
+| `min_length` | strings | Minimum string length |
+| `max_length` | strings | Maximum string length |
+| `enum` | strings | Allowed exact values |
+| `regex` | strings | Pattern match (max 256 chars) |
+| `min_items` | arrays | Minimum list length |
+| `max_items` | arrays | Maximum list length |
+
+### Policy cache
+
+Policies are cached with stale-while-revalidate:
+
+| Window | Default | Behavior |
+|--------|---------|----------|
+| Fresh | 60s | Returns cached policy immediately |
+| Max age | 5min | Returns stale policy while refreshing in background |
+
+Background refreshes use `asyncio.create_task()` to avoid blocking the current validation. The cache requires an active event loop.
+
 ## `VetoCloudClient`
 
 Standalone client for direct cloud API interaction:
@@ -198,6 +232,31 @@ approval = await client.poll_approval("apr_abc123", ApprovalPollOptions(
     timeout=300.0,      # seconds
 ))
 # ApprovalData(id=..., status="approved"|"denied"|"expired", resolved_by=...)
+```
+
+### `await client.fetch_policy(tool_name)`
+
+Fetch a tool's policy from the server. Used by `PolicyCache` for background refreshes.
+
+```python
+policy = await client.fetch_policy("send_email")
+# dict with toolName, mode, constraints, etc.
+# Returns None on error
+```
+
+### `client.log_decision(request)`
+
+Log a client-side validation decision. Fire-and-forget — errors are silently swallowed.
+
+```python
+client.log_decision({
+    "tool_name": "send_email",
+    "arguments": {"to": "user@example.com"},
+    "decision": "allow",
+    "mode": "deterministic",
+    "latency_ms": 2,
+    "source": "client",
+})
 ```
 
 ### `await client.register_tools(tools)`

--- a/content/docs/sdk/typescript.mdx
+++ b/content/docs/sdk/typescript.mdx
@@ -1,6 +1,6 @@
 ---
 title: TypeScript SDK
-description: Full API reference for the Veto TypeScript SDK (v1.3.0).
+description: Full API reference for the Veto TypeScript SDK (v1.4.0).
 ---
 
 ## Installation
@@ -157,6 +157,63 @@ veto.clearApprovalPreferences('read_file');
 veto.clearApprovalPreferences();
 ```
 
+## Client-side deterministic validation
+
+When using cloud mode, the SDK can evaluate deterministic constraints locally — no network round-trip needed. Policies are fetched from the cloud and cached with a stale-while-revalidate strategy.
+
+This is automatic. When the SDK has a cached policy for a tool and that policy uses `deterministic` mode without session constraints or rate limits, validation runs entirely in the SDK. The decision is logged back to the server asynchronously so the dashboard stays accurate.
+
+```
+Agent calls tool
+       │
+       ▼
+Check PolicyCache ─── cache miss ─── POST /v1/validate (server)
+       │
+  cache hit (deterministic, no session/rate constraints)
+       │
+       ▼
+Run local validation
+       │
+       ├── allow ─── Tool executes
+       │
+       └── deny ─── ToolCallDeniedError
+       │
+  POST /v1/decisions (fire-and-forget)
+```
+
+### Supported constraint types
+
+| Constraint | Applies to | Description |
+|-----------|-----------|-------------|
+| `required` | all | Argument must be present |
+| `notNull` | all | Argument cannot be null |
+| `minimum` | numbers | Lower bound (inclusive) |
+| `maximum` | numbers | Upper bound (inclusive) |
+| `greaterThan` | numbers | Lower bound (exclusive) |
+| `lessThan` | numbers | Upper bound (exclusive) |
+| `minLength` | strings | Minimum string length |
+| `maxLength` | strings | Maximum string length |
+| `enum` | strings | Allowed exact values |
+| `regex` | strings | Pattern match (max 256 chars, ReDoS-safe) |
+| `minItems` | arrays | Minimum array length |
+| `maxItems` | arrays | Maximum array length |
+
+### Policy cache
+
+Policies are cached with two time windows:
+
+| Window | Default | Behavior |
+|--------|---------|----------|
+| Fresh | 60s | Returns cached policy immediately |
+| Max age | 5min | Returns stale policy while refreshing in background |
+
+After max age, the cache entry expires and the next validation falls through to the server. Background refreshes are deferred to avoid blocking the current validation.
+
+```typescript
+// PolicyCache is initialized automatically in cloud mode.
+// No configuration needed — it uses sensible defaults.
+```
+
 ## `VetoCloudClient`
 
 Standalone client for direct cloud API interaction. Used internally by `Veto`, but also available for advanced use cases.
@@ -198,6 +255,31 @@ const approval = await client.pollApproval('apr_abc123', {
   timeout: 300000,     // ms
 });
 // { id, toolName, status: "approved" | "denied" | "expired", resolvedBy? }
+```
+
+### `client.fetchPolicy(toolName)`
+
+Fetch a tool's policy from the server. Used by `PolicyCache` for background refreshes.
+
+```typescript
+const policy = await client.fetchPolicy('send_email');
+// { toolName, mode, constraints, sessionConstraints?, rateLimits?, version }
+// Returns null on error (404, network failure, etc.)
+```
+
+### `client.logDecision(request)`
+
+Log a client-side validation decision to the server. Fire-and-forget — errors are silently swallowed.
+
+```typescript
+client.logDecision({
+  tool_name: 'send_email',
+  arguments: { to: 'user@example.com' },
+  decision: 'allow',
+  mode: 'deterministic',
+  latency_ms: 2,
+  source: 'client',
+});
 ```
 
 ### `client.registerTools(tools)`


### PR DESCRIPTION
## Summary
- Bump version references (TypeScript SDK 1.3.0 → 1.4.0, Python SDK 0.3.0 → 0.4.0)
- Document client-side deterministic validation (new in v1.4.0)
- Document policy cache with stale-while-revalidate strategy
- Add constraint type reference tables (numbers, strings, arrays)
- Document `fetchPolicy`/`logDecision` (TS) and `fetch_policy`/`log_decision` (Python) client methods
- Add new `POST /v1/decisions` API reference page
- Update validation modes with client-side fast path explanation
- Note local caching behavior on validate endpoint page

## Files changed
- `content/docs/index.mdx` — add client-side validation to features list
- `content/docs/sdk/typescript.mdx` — v1.4.0, client-side validation, policy cache, new client methods
- `content/docs/sdk/python.mdx` — v0.4.0, client-side validation, policy cache, new client methods
- `content/docs/rules/validation-modes.mdx` — client-side fast path in cloud mode
- `content/docs/api-reference/validate.mdx` — note about local caching reducing server calls
- `content/docs/api-reference/decisions.mdx` — **new** POST /v1/decisions endpoint docs
- `content/docs/api-reference/meta.json` — add decisions to nav