### PR TITLE
Rewrite docs with concepts section and policies API

### DIFF
--- a/content/docs/api-reference/meta.json
+++ b/content/docs/api-reference/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["validate", "decisions", "approvals"]
+  "pages": ["validate", "policies", "decisions", "approvals"]
 }

--- a/content/docs/api-reference/policies.mdx
+++ b/content/docs/api-reference/policies.mdx
@@ -1,0 +1,349 @@
+---
+title: Policies API
+description: CRUD endpoints for managing tool policies — the rules that govern what tool calls are allowed.
+---
+
+Policies define the validation rules for each tool. Each policy is scoped to an organization and identified by tool name (one policy per tool).
+
+All endpoints require authentication via API key (`X-Veto-API-Key`) or Bearer JWT with `X-Organization-Id` header.
+
+## List policies
+
+```
+GET /v1/policies
+```
+
+Returns all policies for the authenticated organization.
+
+### Response
+
+```json
+{
+  "data": [
+    {
+      "toolName": "transfer_funds",
+      "version": 3,
+      "isActive": true,
+      "mode": "deterministic",
+      "constraints": [
+        {
+          "argumentName": "amount",
+          "enabled": true,
+          "minimum": 0,
+          "maximum": 10000,
+          "required": true
+        },
+        {
+          "argumentName": "currency",
+          "enabled": true,
+          "enum": ["USD", "EUR", "GBP"]
+        }
+      ],
+      "createdAt": "2025-01-15T10:00:00Z",
+      "updatedAt": "2025-01-20T14:30:00Z"
+    }
+  ]
+}
+```
+
+## Get policy
+
+```
+GET /v1/policies/:toolName
+```
+
+Returns the policy for a specific tool, including the tool definition if registered.
+
+### Response
+
+```json
+{
+  "toolName": "transfer_funds",
+  "version": 3,
+  "isActive": true,
+  "mode": "deterministic",
+  "constraints": [
+    {
+      "argumentName": "amount",
+      "enabled": true,
+      "minimum": 0,
+      "maximum": 10000,
+      "required": true
+    }
+  ],
+  "sessionConstraints": {
+    "maxCalls": 5,
+    "cumulativeLimits": [
+      { "argumentName": "amount", "maxValue": 50000 }
+    ]
+  },
+  "tool": {
+    "name": "transfer_funds",
+    "description": "Transfer money to an account",
+    "arguments": [
+      { "name": "amount", "type": "number", "required": true },
+      { "name": "to", "type": "string", "required": true }
+    ]
+  },
+  "createdAt": "2025-01-15T10:00:00Z",
+  "updatedAt": "2025-01-20T14:30:00Z"
+}
+```
+
+The SDK calls this endpoint to fetch and cache policies for client-side deterministic validation. See [How Validation Works](/docs/concepts/how-it-works).
+
+### Error: not found
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Policy not found: transfer_funds"
+  }
+}
+```
+
+## Create policy
+
+```
+POST /v1/policies
+```
+
+### Body
+
+```json
+{
+  "toolName": "send_email",
+  "mode": "deterministic",
+  "constraints": [
+    {
+      "argumentName": "to",
+      "enabled": true,
+      "required": true,
+      "regex": "^[^@]+@(company\\.com|partner\\.org)$"
+    },
+    {
+      "argumentName": "body",
+      "enabled": true,
+      "maxLength": 5000
+    }
+  ]
+}
+```
+
+### LLM policy
+
+```json
+{
+  "toolName": "send_email",
+  "mode": "llm",
+  "llmConfig": {
+    "description": "Only allow emails to verified contacts about business topics",
+    "exceptions": ["Emergency notifications are always allowed"],
+    "argumentInstructions": [
+      {
+        "argumentName": "body",
+        "instruction": "Must not contain personally identifiable information"
+      }
+    ],
+    "preferredModel": "anthropic"
+  }
+}
+```
+
+### Session constraints
+
+```json
+{
+  "toolName": "delete_record",
+  "mode": "deterministic",
+  "constraints": [
+    { "argumentName": "id", "enabled": true, "required": true }
+  ],
+  "sessionConstraints": {
+    "maxCalls": 3,
+    "cumulativeLimits": [
+      { "argumentName": "count", "maxValue": 100 }
+    ]
+  }
+}
+```
+
+### Response: 201
+
+```json
+{
+  "toolName": "send_email",
+  "version": 1,
+  "isActive": true,
+  "mode": "deterministic",
+  "constraints": [...],
+  "quality": { "valid": true, "score": 0.95, "issues": [] },
+  "createdAt": "2025-01-20T14:30:00Z"
+}
+```
+
+### Error: 409 conflict
+
+```json
+{
+  "error": {
+    "code": "policy_exists",
+    "message": "Policy for tool 'send_email' already exists"
+  }
+}
+```
+
+## Update policy
+
+```
+PUT /v1/policies/:toolName
+```
+
+Replaces the policy for a tool. Increments the version number. Invalidates the cached policy on all connected SDKs.
+
+### Body
+
+Same schema as create, without `toolName` (taken from the URL).
+
+```json
+{
+  "mode": "deterministic",
+  "constraints": [
+    {
+      "argumentName": "amount",
+      "enabled": true,
+      "minimum": 0,
+      "maximum": 5000
+    }
+  ]
+}
+```
+
+### Response
+
+```json
+{
+  "toolName": "transfer_funds",
+  "version": 4,
+  "isActive": true,
+  "mode": "deterministic",
+  "constraints": [...],
+  "quality": { "valid": true, "score": 0.9, "issues": [] },
+  "updatedAt": "2025-01-21T09:00:00Z"
+}
+```
+
+## Delete policy
+
+```
+DELETE /v1/policies/:toolName
+```
+
+Removes the policy and invalidates any cached copies.
+
+### Response
+
+```json
+{
+  "success": true
+}
+```
+
+## Activate / deactivate
+
+Toggle a policy without deleting it.
+
+```
+POST /v1/policies/:toolName/activate
+POST /v1/policies/:toolName/deactivate
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "message": "Policy for 'transfer_funds' deactivated"
+}
+```
+
+When deactivated, the policy is skipped during validation — tool calls pass through without checks.
+
+## Validate policy (dry run)
+
+Check a policy configuration for quality issues before saving it.
+
+```
+POST /v1/policies/:toolName/validate
+```
+
+### Body
+
+Same schema as create/update.
+
+### Response
+
+```json
+{
+  "valid": true,
+  "score": 0.95,
+  "issues": []
+}
+```
+
+Or with issues:
+
+```json
+{
+  "valid": false,
+  "score": 0.4,
+  "issues": [
+    "Constraint on 'amount' has minimum > maximum",
+    "LLM config description is empty"
+  ]
+}
+```
+
+## Constraint fields
+
+Each constraint in the `constraints` array targets one argument:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `argumentName` | `string` | The tool argument this constraint applies to |
+| `enabled` | `boolean` | Whether this constraint is active |
+| `required` | `boolean?` | Argument must be present |
+| `notNull` | `boolean?` | Argument cannot be null |
+| `minimum` | `number?` | Value must be ≥ threshold |
+| `maximum` | `number?` | Value must be ≤ threshold |
+| `greaterThan` | `number?` | Value must be {">"} threshold |
+| `lessThan` | `number?` | Value must be {"<"} threshold |
+| `greaterThanOrEqual` | `number?` | Alias for `minimum` |
+| `lessThanOrEqual` | `number?` | Alias for `maximum` |
+| `minLength` | `number?` | String must be at least N characters |
+| `maxLength` | `number?` | String must be at most N characters |
+| `enum` | `string[]?` | Value must exactly match one of the allowed strings |
+| `regex` | `string?` | Value must match the pattern (max 256 chars, ReDoS-safe) |
+| `minItems` | `number?` | Array must have at least N elements |
+| `maxItems` | `number?` | Array must have at most N elements |
+
+See [Constraints Reference](/docs/concepts/constraints) for detailed behavior and examples.
+
+## LLM config fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | `string` | Natural language policy the LLM evaluates against |
+| `exceptions` | `string[]` | Conditions where the policy should not apply |
+| `argumentInstructions` | `array?` | Per-argument instructions for the LLM |
+| `preferredModel` | `string?` | `"openai"`, `"anthropic"`, or `"google"` |
+
+## Session constraint fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxCalls` | `number?` | Maximum calls to this tool per session |
+| `cumulativeLimits` | `array?` | Cap cumulative argument values across calls |
+| `cumulativeLimits[].argumentName` | `string` | Argument to track |
+| `cumulativeLimits[].maxValue` | `number` | Maximum cumulative value |

--- a/content/docs/concepts/constraints.mdx
+++ b/content/docs/concepts/constraints.mdx
@@ -1,0 +1,128 @@
+---
+title: Constraints Reference
+description: Every constraint type supported by Veto's deterministic validation — numbers, strings, arrays, and presence checks.
+---
+
+Constraints are the building blocks of deterministic policies. Each constraint targets a single argument and checks one condition. A tool call is denied if any constraint fails.
+
+Constraints are configured per-tool in the [Veto dashboard](https://runveto.com) or via the policy API. They apply to both client-side and server-side deterministic validation.
+
+## Number constraints
+
+| Constraint | Description | Example |
+|-----------|-------------|---------|
+| `minimum` | Value must be ≥ threshold | `minimum: 0` — no negative amounts |
+| `maximum` | Value must be ≤ threshold | `maximum: 10000` — cap at $10,000 |
+| `greaterThan` | Value must be > threshold | `greaterThan: 0` — must be positive |
+| `lessThan` | Value must be < threshold | `lessThan: 100` — below 100 |
+| `greaterThanOrEqual` | Alias for `minimum` | Same as `minimum` |
+| `lessThanOrEqual` | Alias for `maximum` | Same as `maximum` |
+
+NaN and Infinity values always fail number constraints.
+
+**Example policy:** Block transfers over $5,000
+
+```
+argument: amount
+maximum: 5000
+```
+
+If the agent calls `transfer_funds({ amount: 7500 })`, it's denied with:
+
+```json
+{
+  "decision": "deny",
+  "failedArgument": "amount",
+  "reason": "amount 7500 exceeds maximum of 5000"
+}
+```
+
+## String constraints
+
+| Constraint | Description | Example |
+|-----------|-------------|---------|
+| `enum` | Value must exactly match one of the allowed strings | `enum: ["USD", "EUR", "GBP"]` |
+| `regex` | Value must match the regular expression | `regex: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+$"` |
+| `minLength` | String must be at least N characters | `minLength: 1` — no empty strings |
+| `maxLength` | String must be at most N characters | `maxLength: 500` — limit message length |
+
+Regex patterns are capped at 256 characters and checked for ReDoS safety before execution.
+
+**Example policy:** Only allow sending to approved domains
+
+```
+argument: to
+regex: "^[^@]+@(company\\.com|partner\\.org)$"
+```
+
+**Example policy:** Restrict currency to known values
+
+```
+argument: currency
+enum: ["USD", "EUR", "GBP", "JPY"]
+```
+
+## Array constraints
+
+| Constraint | Description | Example |
+|-----------|-------------|---------|
+| `minItems` | Array must have at least N elements | `minItems: 1` — no empty lists |
+| `maxItems` | Array must have at most N elements | `maxItems: 10` — limit batch size |
+
+**Example policy:** Limit bulk operations to 50 items
+
+```
+argument: ids
+maxItems: 50
+```
+
+## Presence constraints
+
+| Constraint | Description | Example |
+|-----------|-------------|---------|
+| `required` | Argument must be present in the call | `required: true` — can't omit this field |
+| `notNull` | Argument cannot be null/None | `notNull: true` — must have a value |
+
+`required` checks that the key exists in the arguments object. `notNull` additionally checks that the value is not null.
+
+## Combining constraints
+
+Multiple constraints on the same argument are AND-ed together. A tool call is denied if any single constraint fails.
+
+**Example:** Amount must be between 1 and 10,000 and is required
+
+```
+argument: amount
+required: true
+minimum: 1
+maximum: 10000
+```
+
+**Example:** Email must be present and match a pattern
+
+```
+argument: email
+required: true
+regex: "^[^@]+@[^@]+\\.[^@]+$"
+maxLength: 254
+```
+
+## Disabling constraints
+
+Set `enabled: false` on any constraint to skip it without deleting the configuration. Useful for temporarily relaxing a policy.
+
+## Python naming
+
+The Python SDK uses snake_case equivalents:
+
+| TypeScript | Python |
+|-----------|--------|
+| `notNull` | `not_null` |
+| `greaterThan` | `greater_than` |
+| `lessThan` | `less_than` |
+| `greaterThanOrEqual` | `greater_than_or_equal` |
+| `lessThanOrEqual` | `less_than_or_equal` |
+| `minLength` | `min_length` |
+| `maxLength` | `max_length` |
+| `minItems` | `min_items` |
+| `maxItems` | `max_items` |

--- a/content/docs/concepts/how-it-works.mdx
+++ b/content/docs/concepts/how-it-works.mdx
@@ -1,0 +1,160 @@
+---
+title: How Validation Works
+description: Architecture of Veto's three validation paths — client-side deterministic, server-side deterministic, and server-side LLM.
+---
+
+When you wrap tools with the Veto SDK, every tool call goes through a validation pipeline before execution. The pipeline picks the fastest validation path that can handle your policy.
+
+## The validation pipeline
+
+```
+Agent calls wrapped tool
+         │
+         ▼
+  ┌─────────────────┐
+  │ Is the policy    │──── no ───▶ POST /v1/tools/validate
+  │ cached locally?  │            (server-side validation)
+  └────────┬────────┘
+           │ yes
+           ▼
+  ┌─────────────────┐
+  │ Policy mode is   │──── no ───▶ POST /v1/tools/validate
+  │ deterministic?   │            (server-side LLM)
+  └────────┬────────┘
+           │ yes
+           ▼
+  ┌─────────────────┐
+  │ Has session or   │──── yes ──▶ POST /v1/tools/validate
+  │ rate constraints? │            (server handles state)
+  └────────┬────────┘
+           │ no
+           ▼
+  Run constraints locally (~1-5ms)
+           │
+      ┌────┴────┐
+      │         │
+    allow     deny
+      │         │
+      ▼         ▼
+  Tool runs   ToolCallDeniedError
+      │         │
+      └────┬────┘
+           ▼
+  POST /v1/decisions (async, fire-and-forget)
+```
+
+## Path 1: Client-side deterministic
+
+The fastest path. The SDK evaluates constraints locally using a cached copy of the policy.
+
+**When it triggers:**
+- The tool's policy is cached (fetched on first call, background-refreshed every 60s)
+- The policy mode is `deterministic`
+- The policy has no session constraints or rate limits
+
+**What it checks:**
+- Number ranges (`minimum`, `maximum`, `greaterThan`, `lessThan`)
+- String validation (`enum`, `regex`, `minLength`, `maxLength`)
+- Array bounds (`minItems`, `maxItems`)
+- Required/null checks (`required`, `notNull`)
+
+**Latency:** ~1-5ms (no network call)
+
+**Decision logging:** The decision is sent to `POST /v1/decisions` asynchronously so the dashboard stays accurate. This never blocks tool execution.
+
+See [Constraints Reference](/docs/concepts/constraints) for every supported constraint type.
+
+## Path 2: Server-side deterministic
+
+The server evaluates the same constraint types as client-side, but also handles stateful checks that require server coordination.
+
+**When it triggers:**
+- Cache miss (first call for a tool, or policy expired)
+- Policy has session constraints (per-session call limits, argument tracking)
+- Policy has rate limits
+
+**What it checks:** Everything client-side checks, plus:
+- Session constraints (e.g. "max 3 calls to `delete_record` per session")
+- Rate limits (e.g. "max 10 calls per minute")
+- Cross-tool constraints (e.g. "if `read_file` was called, block `send_email`")
+
+**Latency:** ~30-50ms (one network round-trip)
+
+## Path 3: Server-side LLM
+
+An LLM evaluates the tool call against natural language policies and exception lists. Use this for checks that can't be expressed as static constraints.
+
+**When it triggers:**
+- Policy mode is `llm`
+
+**What it checks:**
+- Semantic evaluation against the policy description
+- Exception lists (e.g. "deny transfers to external accounts, except for verified vendors")
+- Complex multi-argument relationships
+- Context-dependent decisions
+
+**Latency:** ~500-2000ms (network + LLM inference)
+
+**Supported models:** Claude (Anthropic), GPT-4o-mini (OpenAI). Configured per-policy in the dashboard.
+
+## Policy cache
+
+The SDK caches policies locally using a stale-while-revalidate strategy:
+
+| Window | Duration | Behavior |
+|--------|----------|----------|
+| **Fresh** | 0 – 60s | Serve from cache immediately |
+| **Stale** | 60s – 5min | Serve from cache, refresh in background |
+| **Expired** | > 5min | Cache miss, fall through to server |
+
+When a policy is stale, the SDK returns the cached version instantly while fetching the latest version in the background. This means validation latency is consistently low even when policies change — the next call after the background refresh completes will use the updated policy.
+
+Policy changes made in the dashboard take effect within 60 seconds on all connected SDKs.
+
+## Decision flow for approvals
+
+When a policy is configured for human-in-the-loop review, the server returns `require_approval` instead of `allow` or `deny`:
+
+```
+POST /v1/tools/validate
+         │
+         ▼
+  decision: "require_approval"
+  approval_id: "apr_..."
+         │
+         ▼
+  SDK fires onApprovalRequired hook
+  (your app shows approval UI)
+         │
+         ▼
+  SDK polls GET /v1/approvals/:id
+  every 2 seconds (configurable)
+         │
+    ┌────┴─────────┐
+    │              │
+  approved       denied / expired / timeout
+    │              │
+  Tool runs     ToolCallDeniedError / ApprovalTimeoutError
+```
+
+Configure the approval hook when initializing the SDK:
+
+```typescript
+const veto = await Veto.init({
+  onApprovalRequired: (context, approvalId) => {
+    // Show approval UI, send notification, etc.
+  },
+});
+```
+
+## Offline validation modes
+
+Besides Veto Cloud, the SDK supports three offline modes that don't require the Veto server:
+
+| Mode | How it works | Config key |
+|------|-------------|------------|
+| **Custom** | Calls an LLM provider directly (OpenAI, Anthropic, Gemini) | `validation.mode: "custom"` |
+| **Kernel** | Uses a local Ollama model | `validation.mode: "kernel"` |
+| **API** | Sends to a self-hosted validation endpoint | `validation.mode: "api"` |
+
+See [Validation Modes](/docs/rules/validation-modes) for configuration details.

--- a/content/docs/concepts/meta.json
+++ b/content/docs/concepts/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["how-it-works", "constraints"]
+}

--- a/content/docs/getting-started/quick-start.mdx
+++ b/content/docs/getting-started/quick-start.mdx
@@ -1,85 +1,219 @@
 ---
 title: Quick Start
-description: Get Veto running in 5 minutes.
+description: Get Veto running in 5 minutes with Veto Cloud.
 ---
 
-## 1. Install and initialize
+This guide uses Veto Cloud — the fastest way to get started. You'll need an API key from the [Veto dashboard](https://runveto.com).
+
+## 1. Install the SDK
 
 ```bash
 npm install veto-sdk
+```
+
+Or with Python:
+
+```bash
+pip install veto
+```
+
+## 2. Initialize configuration
+
+```bash
 npx veto init
 ```
 
-## 2. Define a rule
+This creates a `veto/` directory with your config:
 
-Edit `veto/rules/default.yaml`:
-
-```yaml
-rules:
-  - id: limit-transfers
-    name: Limit large transfers
-    action: block
-    tools:
-      - transfer_funds
-    conditions:
-      - field: arguments.amount
-        operator: greater_than
-        value: 1000
+```
+veto/
+├── veto.config.yaml
+└── rules/
+    └── default.yaml
 ```
 
-This rule blocks any call to `transfer_funds` where the amount exceeds 1000.
-
-## 3. Wrap your tools
-
-```typescript
-import { Veto } from 'veto-sdk';
-
-// Your existing tools
-const myTools = [transferFundsTool, sendEmailTool, readFileTool];
-
-// Initialize Veto (loads config from ./veto)
-const veto = await Veto.init();
-
-// Wrap tools with validation
-const wrappedTools = veto.wrap(myTools);
-
-// Pass to your agent — the interface is identical
-const agent = createAgent({
-  tools: wrappedTools,
-});
-```
-
-When the agent calls `transfer_funds({ amount: 5000 })`, Veto intercepts and blocks it. The agent receives a `ToolCallDeniedError` and can try a different approach.
-
-## 4. Configure validation mode
-
-Edit `veto/veto.config.yaml` to choose how validation runs:
+Edit `veto/veto.config.yaml`:
 
 ```yaml
 version: "1.0"
 mode: "strict"
 
 validation:
-  mode: "cloud"     # "cloud", "api", "custom", or "kernel"
+  mode: "cloud"
 
 cloud:
-  apiKey: "veto_abc123..."
-
-rules:
-  directory: "./rules"
-  recursive: true
+  apiKey: "veto_your_key_here"
 ```
 
-| Mode | How it works | When to use |
-|------|-------------|-------------|
-| `cloud` | Validates via Veto Cloud API with approval workflows | Production with dashboard + human-in-the-loop |
-| `api` | Sends validation requests to a self-hosted API | Self-hosted deployments |
-| `custom` | Calls an LLM provider directly | Development, no server needed |
-| `kernel` | Uses a local Ollama model | Offline, air-gapped environments |
+Or set the `VETO_API_KEY` environment variable instead of putting the key in the config file.
+
+## 3. Configure policies in the dashboard
+
+Go to the [Veto dashboard](https://runveto.com) and create policies for your tools. Each policy defines what constraints to check for a specific tool.
+
+**Example:** For a `transfer_funds` tool, you might set:
+- `amount`: maximum 10000, minimum 0, required
+- `currency`: enum ["USD", "EUR", "GBP"]
+
+The SDK fetches these policies automatically and caches them locally for fast validation.
+
+## 4. Wrap your tools
+
+```typescript
+import { Veto } from 'veto-sdk';
+
+const veto = await Veto.init();
+const wrappedTools = veto.wrap(myTools);
+
+const agent = createAgent({ tools: wrappedTools });
+```
+
+That's it. Every tool call now goes through Veto.
+
+## What happens next
+
+When the agent calls a tool:
+
+1. **Deterministic policies** are checked locally in ~1-5ms (cached from the cloud)
+2. **LLM policies** are sent to the cloud for semantic validation in ~500-2000ms
+3. **Approval policies** pause execution until a human approves in the dashboard
+4. **Allowed** calls execute normally. **Denied** calls throw `ToolCallDeniedError`.
+5. Every decision is logged to the dashboard for audit and monitoring.
+
+## Framework examples
+
+### OpenAI
+
+```typescript
+import OpenAI from 'openai';
+import { Veto } from 'veto-sdk';
+
+const openai = new OpenAI();
+const veto = await Veto.init();
+
+const tools = veto.wrap([
+  {
+    type: 'function',
+    function: {
+      name: 'transfer_funds',
+      description: 'Transfer money to an account',
+      parameters: {
+        type: 'object',
+        properties: {
+          amount: { type: 'number' },
+          to: { type: 'string' },
+        },
+      },
+    },
+  },
+]);
+
+const response = await openai.chat.completions.create({
+  model: 'gpt-4o',
+  tools,
+  messages: [{ role: 'user', content: 'Transfer $500 to Alice' }],
+});
+```
+
+### Anthropic
+
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+import { Veto } from 'veto-sdk';
+
+const anthropic = new Anthropic();
+const veto = await Veto.init();
+
+const tools = veto.wrap([
+  {
+    name: 'send_email',
+    description: 'Send an email',
+    input_schema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string' },
+        subject: { type: 'string' },
+        body: { type: 'string' },
+      },
+    },
+  },
+]);
+
+const response = await anthropic.messages.create({
+  model: 'claude-sonnet-4-5-20250929',
+  max_tokens: 1024,
+  tools,
+  messages: [{ role: 'user', content: 'Email the team about the outage' }],
+});
+```
+
+### Vercel AI SDK
+
+```typescript
+import { generateText, tool } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { Veto } from 'veto-sdk';
+import { z } from 'zod';
+
+const veto = await Veto.init();
+
+const tools = veto.wrap({
+  transferFunds: tool({
+    description: 'Transfer money',
+    parameters: z.object({
+      amount: z.number(),
+      to: z.string(),
+    }),
+    execute: async ({ amount, to }) => {
+      return { success: true, amount, to };
+    },
+  }),
+});
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prompt: 'Transfer $500 to Alice',
+});
+```
+
+### Python (OpenAI)
+
+```python
+from openai import OpenAI
+from veto import Veto
+
+client = OpenAI()
+veto = await Veto.init()
+
+tools = veto.wrap([
+    {
+        "type": "function",
+        "function": {
+            "name": "transfer_funds",
+            "description": "Transfer money to an account",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "amount": {"type": "number"},
+                    "to": {"type": "string"},
+                },
+            },
+        },
+    },
+])
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    tools=tools,
+    messages=[{"role": "user", "content": "Transfer $500 to Alice"}],
+)
+```
 
 ## Next steps
 
+- [How Validation Works](/docs/concepts/how-it-works) — understand the three validation paths
+- [Constraints Reference](/docs/concepts/constraints) — every constraint type explained
 - [TypeScript SDK](/docs/sdk/typescript) — full API reference
 - [Python SDK](/docs/sdk/python) — full API reference
-- [YAML Rule Format](/docs/rules/yaml-format) — complete rule syntax
-- [Validation Modes](/docs/rules/validation-modes) — deep dive into each mode
+- [POST /v1/tools/validate](/docs/api-reference/validate) — validation API reference

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,66 +3,67 @@ title: What is Veto?
 description: The permission layer for AI agents. Intercept, validate, and control every tool call.
 ---
 
-Veto is a guardrail system for AI agent tool calls. It sits between an AI agent and its tools — intercepting every tool call, validating it against rules and policies, and allowing, blocking, or escalating for human approval.
-
-The agent is unaware of the guardrail. The tool interface is preserved.
-
-## How it works
-
-1. AI agent calls a tool (e.g. `send_email({to: "...", body: "..."})`)
-2. Veto intercepts the call via the SDK
-3. Arguments are validated against your policies (deterministic constraints + LLM semantic checks)
-4. The call is allowed, blocked, or escalated for human approval
-5. If allowed, the tool executes normally. If blocked, the agent receives an error. If escalated, a human reviewer approves or denies.
+Veto sits between an AI agent and its tools. Every tool call is intercepted, validated against your policies, and either allowed, blocked, or escalated for human approval. The agent never knows the guardrail exists.
 
 ```
-┌──────────┐     ┌───────┐     ┌──────────┐
-│ AI Agent │────▶│ Veto  │────▶│  Tools   │
-│          │     │       │     │          │
-│  calls   │     │ rules │     │ execute  │
-│  tools   │     │ + LLM │     │ actions  │
-└──────────┘     └───────┘     └──────────┘
-                    │
-                    ▼
-              ┌──────────┐
-              │  Human   │
-              │ Approval │
-              └──────────┘
+Agent calls tool ──▶ Veto validates ──▶ Tool executes
+                         │
+                    ┌────┴────┐
+                    │         │
+                  allow     deny / require approval
 ```
 
-## Features
+## Three validation paths
 
-- **Provider agnostic** — works with OpenAI, Anthropic, Google, LangChain, Vercel AI SDK
-- **YAML rules** — define constraints with simple, declarative YAML
-- **Client-side validation** — deterministic constraints evaluated locally with zero network latency. Policies synced from the cloud and cached with stale-while-revalidate.
-- **LLM validation** — semantic checks for cases static rules can't cover
-- **Human-in-the-loop** — escalate sensitive tool calls for human approval before execution
-- **Approval preferences** — cache approve/deny decisions per tool to skip repeated reviews
-- **Multiple validation modes** — cloud (managed), API (self-hosted), custom (direct LLM), or kernel (local Ollama)
-- **TypeScript + Python SDKs** — first-class support for both languages with identical APIs
-- **Dashboard** — real-time monitoring at [runveto.com](https://runveto.com)
+When using Veto Cloud, tool calls are validated through one of three paths depending on how you configure each tool's policy:
 
-## Quick example
+| Path | Where | Latency | Use case |
+|------|-------|---------|----------|
+| **Client-side deterministic** | SDK | ~1-5ms | Number ranges, string enums, regex, required fields |
+| **Server-side deterministic** | Veto Cloud | ~30-50ms | Same constraints + session limits + rate limits |
+| **Server-side LLM** | Veto Cloud | ~500-2000ms | Semantic checks, exception lists, natural language policies |
+
+The SDK automatically picks the fastest path. Deterministic policies are cached locally and validated without a network call. LLM policies and policies with session/rate constraints always go through the server.
+
+## Get started in 3 steps
+
+**1. Install the SDK**
+
+```bash
+npm install veto-sdk    # TypeScript
+pip install veto        # Python
+```
+
+**2. Get an API key** from the [Veto dashboard](https://runveto.com) and configure policies for your tools.
+
+**3. Wrap your tools**
 
 ```typescript
 import { Veto } from 'veto-sdk';
 
-const veto = await Veto.init({
-  onApprovalRequired: (context, approvalId) => {
-    console.log(`"${context.toolName}" needs approval: ${approvalId}`);
-  },
-});
-
+const veto = await Veto.init();
 const wrappedTools = veto.wrap(myTools);
 
-// Pass wrapped tools to your agent — it works exactly the same,
-// but every call is now validated against your policies
+// Pass wrapped tools to your agent — the interface is identical
 const agent = createAgent({ tools: wrappedTools });
 ```
 
+Every tool call is now validated against your policies. The agent code doesn't change.
+
+## Features
+
+- **Zero-config fast path** — deterministic constraints run locally in the SDK with no network call
+- **Provider agnostic** — OpenAI, Anthropic, Google, LangChain, Vercel AI SDK, browser-use
+- **Human-in-the-loop** — escalate sensitive tool calls for human approval before execution
+- **LLM validation** — natural language policies for cases static rules can't cover
+- **Session-aware** — track per-session call counts, argument history, and cross-tool constraints
+- **TypeScript + Python** — identical APIs, identical behavior
+- **Real-time dashboard** — monitor every decision at [runveto.com](https://runveto.com)
+
 ## Next steps
 
-- [Installation](/docs/getting-started/installation) — install the SDK for TypeScript or Python
-- [Quick Start](/docs/getting-started/quick-start) — get Veto running in 5 minutes
-- [Rule Format](/docs/rules/yaml-format) — learn the YAML rule syntax
-- [Validation Modes](/docs/rules/validation-modes) — cloud, API, custom, and kernel modes
+- [Quick Start](/docs/getting-started/quick-start) — end-to-end setup in 5 minutes
+- [How Validation Works](/docs/concepts/how-it-works) — architecture deep dive
+- [Constraints Reference](/docs/concepts/constraints) — every constraint type explained
+- [TypeScript SDK](/docs/sdk/typescript) — full API reference
+- [Python SDK](/docs/sdk/python) — full API reference

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -5,6 +5,8 @@
     "index",
     "---Getting Started---",
     "...getting-started",
+    "---Concepts---",
+    "...concepts",
     "---SDKs---",
     "...sdk",
     "---Rules---",

--- a/content/docs/rules/validation-modes.mdx
+++ b/content/docs/rules/validation-modes.mdx
@@ -3,65 +3,92 @@ title: Validation Modes
 description: How Veto validates tool calls — cloud, API, custom, and kernel modes.
 ---
 
-Veto supports four validation modes, configured in `veto.config.yaml`:
+Veto supports four validation modes. Set the mode in `veto.config.yaml`:
 
 ```yaml
 validation:
-  mode: "cloud"  # "cloud", "api", "custom", or "kernel"
+  mode: "cloud"  # "cloud" | "api" | "custom" | "kernel"
 ```
 
-## Cloud mode
+## Cloud mode (recommended)
 
-Routes validation through the Veto Cloud API with full policy management, decision logging, and human-in-the-loop approval workflows.
+Routes validation through the Veto Cloud API. Policies are managed in the [dashboard](https://runveto.com) — the SDK fetches and caches them automatically.
 
 ```yaml
 validation:
   mode: "cloud"
 
 cloud:
-  apiKey: "veto_abc123..."
+  apiKey: "veto_abc123..."   # or set VETO_API_KEY env var
   baseUrl: "https://api.runveto.com"
   timeout: 30000
   retries: 2
 
 approval:
   pollInterval: 2000   # ms between polls
-  timeout: 300000      # max ms to wait (5 min)
+  timeout: 300000      # max wait (5 min)
 ```
+
+### Three validation paths
+
+Cloud mode uses the fastest validation path that can handle each policy:
+
+| Path | Where it runs | Latency | When it triggers |
+|------|--------------|---------|-----------------|
+| **Client-side deterministic** | SDK (local) | ~1-5ms | Policy is cached, mode is `deterministic`, no session/rate constraints |
+| **Server-side deterministic** | Veto Cloud | ~30-50ms | Cache miss, or policy has session constraints or rate limits |
+| **Server-side LLM** | Veto Cloud | ~500-2000ms | Policy mode is `llm` |
+
+The SDK picks the path automatically. You configure the policy — the routing is handled for you.
+
+### Client-side deterministic
+
+When the SDK has a cached deterministic policy with no session or rate constraints, it evaluates constraints locally. No network call. Decisions are logged to the server asynchronously via `POST /v1/decisions` so the dashboard stays accurate.
+
+Supported constraints: `minimum`, `maximum`, `greaterThan`, `lessThan`, `enum`, `regex`, `minLength`, `maxLength`, `minItems`, `maxItems`, `required`, `notNull`. See [Constraints Reference](/docs/concepts/constraints).
+
+### Server-side deterministic
+
+Same constraint types, plus stateful checks that require server coordination:
+
+- **Session constraints** — e.g. "max 3 calls to `delete_record` per session"
+- **Rate limits** — e.g. "max 10 calls per minute"
+- **Cross-tool constraints** — e.g. "if `read_file` was called, block `send_email`"
+
+### Server-side LLM
+
+An LLM evaluates the tool call against natural language policies. Use this for checks that can't be expressed as static constraints:
+
+- Semantic evaluation against a policy description
+- Exception lists (e.g. "deny transfers to external accounts, except for verified vendors")
+- Complex multi-argument relationships
+- Context-dependent decisions
+
+### Three decisions
 
 The cloud can return three decisions:
 
 | Decision | What happens |
 |----------|-------------|
 | `allow` | Tool call proceeds |
-| `deny` | Tool call is blocked |
-| `require_approval` | SDK pauses and polls until a human approves or denies |
+| `deny` | `ToolCallDeniedError` is thrown |
+| `require_approval` | SDK pauses and polls until a human approves or denies in the dashboard |
 
-When `require_approval` is returned, the SDK fires the `onApprovalRequired` hook (TypeScript) or `on_approval_required` callback (Python), then polls `GET /v1/approvals/:id` until resolved. This enables integrations like the Veto dashboard to present approve/deny UI to a human reviewer.
+### Policy cache
 
-### Client-side fast path
+Policies are cached with stale-while-revalidate:
 
-In cloud mode, the SDK caches policies locally and evaluates deterministic constraints without a network round-trip. This happens automatically when:
+| Window | Duration | Behavior |
+|--------|----------|----------|
+| **Fresh** | 0–60s | Serve from cache |
+| **Stale** | 60s–5min | Serve from cache, refresh in background |
+| **Expired** | >5min | Fall through to server |
 
-1. The tool's policy is cached (fetched on first call, refreshed in background)
-2. The policy mode is `deterministic` (not `llm`)
-3. The policy has no session constraints or rate limits
-
-When all three conditions are met, validation runs in the SDK (~1-5ms). The decision is logged to the server asynchronously via `POST /v1/decisions` so the dashboard stays accurate.
-
-If any condition is not met, the SDK falls through to `POST /v1/validate` as before.
-
-Best for production deployments. Provides:
-- Centralized policy management via the dashboard at [runveto.com](https://runveto.com)
-- Client-side deterministic validation with zero-latency cache hits
-- Deterministic and LLM-assisted validation
-- Real-time decision logging
-- Human-in-the-loop approval workflows
-- Team-wide visibility and audit trails
+Policy changes in the dashboard propagate to all connected SDKs within 60 seconds.
 
 ## API mode
 
-Sends validation requests to a self-hosted or external validation API at `POST /tool/call/check`.
+Sends validation requests to a self-hosted endpoint. Use this when you want full control over the validation backend.
 
 ```yaml
 validation:
@@ -71,22 +98,20 @@ validation:
     endpoint: "/tool/call/check"
 ```
 
-Best for self-hosted deployments or custom validation backends.
+The endpoint receives the tool name and arguments as JSON and must return `{ decision: "allow" | "deny" }`.
 
 ## Custom mode
 
-Calls an LLM provider directly from the SDK. No server needed.
+Calls an LLM provider directly from the SDK. No server needed. Rules are evaluated using the LLM with the YAML rules in your `veto/rules/` directory.
 
 ```yaml
 validation:
   mode: "custom"
 
 custom:
-  provider: "openai"     # openai, anthropic, or gemini
+  provider: "openai"     # openai | anthropic | gemini
   model: "gpt-4o-mini"
 ```
-
-Supported providers:
 
 | Provider | Models | Env variable |
 |----------|--------|-------------|
@@ -94,11 +119,11 @@ Supported providers:
 | `anthropic` | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` |
 | `gemini` | `gemini-3-flash-preview` | `GOOGLE_API_KEY` |
 
-Best for development and testing. Rules are evaluated locally using the LLM.
+Best for development and testing when you don't need the dashboard or audit trails.
 
 ## Kernel mode
 
-Uses a local Ollama model for fully offline validation.
+Uses a local Ollama model for fully offline validation. Zero external API calls.
 
 ```yaml
 validation:
@@ -109,11 +134,11 @@ kernel:
   model: "llama3"
 ```
 
-Requires [Ollama](https://ollama.ai) running locally. Best for air-gapped environments or when you need zero external API calls.
+Requires [Ollama](https://ollama.ai) running locally. Best for air-gapped environments.
 
 ## Operating modes
 
-Separate from validation mode, Veto has two operating modes:
+Orthogonal to validation mode, Veto has two operating modes that control what happens when a tool call is denied:
 
 ```yaml
 mode: "strict"  # or "log"
@@ -124,4 +149,4 @@ mode: "strict"  # or "log"
 | `strict` | Blocks denied calls — throws `ToolCallDeniedError` |
 | `log` | Logs denied calls but allows execution to continue |
 
-Use `log` mode during initial rollout to observe what would be blocked without affecting agent behavior.
+Use `log` mode during initial rollout to observe what would be blocked without affecting agent behavior. Switch to `strict` once you're confident in your policies.

--- a/content/docs/sdk/cli.mdx
+++ b/content/docs/sdk/cli.mdx
@@ -34,13 +34,26 @@ veto/
     └── default.yaml    # Default rule template
 ```
 
-If the `veto/` directory already exists, the command will not overwrite existing files.
+The generated `veto.config.yaml` defaults to cloud mode:
+
+```yaml
+version: "1.0"
+mode: "strict"
+
+validation:
+  mode: "cloud"
+
+cloud:
+  apiKey: "veto_your_key_here"
+```
+
+If the `veto/` directory already exists, the command does not overwrite existing files.
 
 ### `veto version`
 
-Prints the current Veto SDK version.
+Prints the current SDK version.
 
 ```bash
 npx veto version
-# veto-sdk@1.2.0
+# veto-sdk@1.4.0
 ```


### PR DESCRIPTION
## Summary

- Add **Concepts** section with two new pages: "How Validation Works" (three validation paths architecture) and "Constraints Reference" (every constraint type)
- Rewrite **Quick Start** as cloud-first with framework examples (OpenAI, Anthropic, Vercel AI SDK, Python)
- Rewrite **Validation Modes** with three-path table under cloud mode, cleaner structure for API/custom/kernel
- Add **Policies API** reference page (full CRUD: list, get, create, update, delete, activate/deactivate, dry-run validate)
- Update **index page** with validation paths overview table and simplified getting-started steps
- Update **CLI** page with generated config example and version bump to 1.4.0
- Update nav structure (`meta.json`) to include Concepts section and Policies in API Reference

## Test plan

- [x] `pnpm build` passes with no errors
- [ ] Verify all internal links resolve correctly on deployed site
- [ ] Spot-check code examples against actual SDK/server behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Policies API reference with CRUD operations, constraints, and examples
  * Added Constraints Reference guide for validation rule configuration
  * Added How Validation Works guide explaining validation paths and flows
  * Revised Quick Start documentation with updated setup and SDK integration
  * Updated main documentation with refined validation workflow explanations
  * Enhanced CLI documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->