### PR TITLE
docs: add Polymarket Veto MCP launch guide

### DIFF
--- a/content/docs/guides/mcp-gateway.mdx
+++ b/content/docs/guides/mcp-gateway.mdx
@@ -131,3 +131,4 @@ Resolution:
 - [CLI reference](/docs/sdk/cli)
 - [MCP API reference](/docs/api-reference/mcp)
 - [MCP SDK integration](/docs/integrations/mcp)
+- [Polymarket with Veto MCP](/docs/guides/polymarket-veto-mcp)

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "pages": [
+    "polymarket-veto-mcp",
     "post-launch-runbook-rollback",
     "mcp-gateway",
     "policy-drafts-review",

--- a/content/docs/guides/polymarket-veto-mcp.mdx
+++ b/content/docs/guides/polymarket-veto-mcp.mdx
@@ -1,0 +1,135 @@
+---
+title: Polymarket With Veto MCP
+description: Run Polymarket trading tools behind Veto policies for agent-safe execution.
+---
+
+This guide shows how to run a guarded MCP sidecar for Polymarket so AI agents can query markets safely and route risky mutations through Veto policy checks.
+
+Tagline: **Polymarket CLI, but safe for agents.**
+
+## Architecture
+
+```text
+Agent (Claude/Cursor/MCP client)
+  -> polymarket-veto-mcp sidecar
+    -> Veto policy validation (local or cloud)
+      -> polymarket CLI command execution
+```
+
+Decision mapping:
+
+- `allow`: command executes (or simulates for mutating tools in safe mode)
+- `deny`: JSON-RPC error `-32001`
+- `require_approval`: JSON-RPC error `-32002`
+
+## 1) Install Polymarket CLI
+
+Follow upstream install instructions first:
+
+- [Polymarket CLI](https://github.com/Polymarket/polymarket-cli)
+
+Quick check:
+
+```bash
+polymarket --version
+```
+
+## 2) Start guarded MCP sidecar
+
+```bash
+npx @vulnzap/polymarket-veto-mcp serve
+```
+
+Default runtime posture:
+
+- transport: `stdio`
+- policy profile: `defaults`
+- mutating tools: simulation-first
+- live trading: disabled unless explicitly enabled
+
+## 3) Inspect tools and health
+
+```bash
+npx @vulnzap/polymarket-veto-mcp print-tools
+npx @vulnzap/polymarket-veto-mcp doctor
+```
+
+## 4) Policy profiles
+
+The sidecar supports three launch profiles:
+
+- `defaults`: launch-safe baseline
+- `conservative`: stricter approvals / more blocks
+- `agent`: autonomous-but-contained profile
+
+Select profile at startup:
+
+```bash
+npx @vulnzap/polymarket-veto-mcp serve --policy-profile defaults
+```
+
+## 5) Simulation vs live execution
+
+Mutating tools are simulated by default.
+
+To allow live execution you must satisfy all three:
+
+1. start with `--simulation off` (or config equivalent)
+2. set `execution.allowLiveTrades: true`
+3. export `ALLOW_LIVE_TRADES=true`
+
+This prevents accidental wallet-impacting actions from autonomous agents.
+
+## 6) Local-first and optional cloud mode
+
+The default Veto config is local deterministic mode.
+
+If you want cloud-backed validation, set in `veto/veto.config.yaml`:
+
+```yaml
+validation:
+  mode: cloud
+cloud:
+  baseUrl: https://api.runveto.com
+```
+
+Then set your API key:
+
+```bash
+export VETO_API_KEY=veto_xxx
+```
+
+## Tool coverage in v1
+
+Read-only:
+
+- `markets_list`
+- `markets_search`
+- `markets_get`
+- `clob_book`
+- `clob_midpoint`
+- `clob_price`
+- `portfolio_positions`
+
+Mutating (policy-guarded):
+
+- `order_create_limit`
+- `order_market`
+- `order_cancel`
+- `order_cancel_all`
+- `approve_set`
+- `ctf_split`
+- `ctf_merge`
+- `ctf_redeem`
+
+Not exposed:
+
+- `wallet_import`
+- `wallet_reset`
+- `clob_delete_api_key`
+
+## Related
+
+- [MCP Gateway](/docs/guides/mcp-gateway)
+- [MCP Integration](/docs/integrations/mcp)
+- [CLI Reference](/docs/sdk/cli)

--- a/content/docs/guides/polymarket-veto-mcp.mdx
+++ b/content/docs/guides/polymarket-veto-mcp.mdx
@@ -37,7 +37,7 @@ polymarket --version
 ## 2) Start guarded MCP sidecar
 
 ```bash
-npx @vulnzap/polymarket-veto-mcp serve
+npx @plawio/polymarket-veto-mcp serve
 ```
 
 Default runtime posture:
@@ -50,8 +50,8 @@ Default runtime posture:
 ## 3) Inspect tools and health
 
 ```bash
-npx @vulnzap/polymarket-veto-mcp print-tools
-npx @vulnzap/polymarket-veto-mcp doctor
+npx @plawio/polymarket-veto-mcp print-tools
+npx @plawio/polymarket-veto-mcp doctor
 ```
 
 ## 4) Policy profiles
@@ -65,7 +65,7 @@ The sidecar supports three launch profiles:
 Select profile at startup:
 
 ```bash
-npx @vulnzap/polymarket-veto-mcp serve --policy-profile defaults
+npx @plawio/polymarket-veto-mcp serve --policy-profile defaults
 ```
 
 ## 5) Simulation vs live execution

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -93,4 +93,5 @@ The SDK wraps any tool format. Deep integrations for [OpenAI SDK](/docs/integrat
 | [Quick Start](/docs/getting-started/quick-start) | End-to-end setup with runnable examples for every framework |
 | [YAML Rule Format](/docs/rules/yaml-format) | Complete rule syntax — actions, conditions, severity levels |
 | [How Validation Works](/docs/concepts/how-it-works) | Architecture deep dive — caching, approval flow, session tracking |
+| [Polymarket With Veto MCP](/docs/guides/polymarket-veto-mcp) | Agent-safe trading workflow with simulation-first guardrails |
 | [Post-launch Runbook](/docs/guides/post-launch-runbook-rollback) | Deploy order, smoke checks, incident triage, and rollback steps |

--- a/content/docs/integrations/mcp.mdx
+++ b/content/docs/integrations/mcp.mdx
@@ -7,6 +7,8 @@ Veto supports [Model Context Protocol (MCP)](https://modelcontextprotocol.io) to
 
 If you want Veto to act as an MCP gateway service (managed or self-hosted), use [MCP Gateway guide](/docs/guides/mcp-gateway). This page focuses on direct SDK-level MCP tool integration.
 
+For a real trading-tool showcase, see [Polymarket with Veto MCP](/docs/guides/polymarket-veto-mcp).
+
 ## Quick start
 
 Pass MCP tool definitions directly to `veto.wrap()`:

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -101,6 +101,7 @@ guarded_tools = veto.wrap(tools)
 - Human auth for CLI: `veto cloud login`
 - Managed MCP gateway: `/v1/mcp/:upstreamSlug` (SSE upstream in managed mode)
 - Self-hosted MCP gateway: `veto mcp serve` (supports `mcp-sse` and `mcp-stdio`)
+- Polymarket showcase: https://docs.runveto.com/docs/guides/polymarket-veto-mcp
 
 ## skills.sh Skill
 


### PR DESCRIPTION
## Summary
- add new guide: `/docs/guides/polymarket-veto-mcp`
- document sidecar architecture, simulation/live model, and tool coverage
- link new guide from MCP Gateway, MCP Integration, and docs index
- update `public/llms.txt` with Polymarket showcase guide link

## Validation
- `pnpm build`
